### PR TITLE
update: Helium to `0.4.7.2`

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -6,7 +6,7 @@
 pkgbase = helium-browser-bin
 	pkgdesc = Private, fast, and honest web browser based on Chromium
 	pkgver = 0.4.7.2
-	pkgrel = 1
+	pkgrel = 3
 	url = https://github.com/imputnet/helium-linux
 	arch = x86_64
 	license = GPL-3.0-only
@@ -34,7 +34,7 @@ pkgbase = helium-browser-bin
 	optdepends = upower: Battery Status API support
 	options = strip
 	source_x86_64 = helium-0.4.7.2-x86_64_linux.tar.xz::https://github.com/imputnet/helium-linux/releases/download/0.4.7.2/helium-0.4.7.2-x86_64_linux.tar.xz
-	source_x86_64 = helium.desktop::https://raw.githubusercontent.com/imputnet/helium-linux/main/package/helium.desktop
+	source_x86_64 = https://raw.githubusercontent.com/imputnet/helium-linux/0.4.7.2/package/helium.desktop
 	sha256sums_x86_64 = b8e1f57dffa7cf014a36b202359294654f978c9e912c380ebd2054d9ea2e4fc8
 	sha256sums_x86_64 = cce8668c18d33077a585cb5d96522e5a02ae017a2baf800f8d7214ce6d05d3d2
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="${_pkgname}-browser-bin"
 _binaryname="helium-browser"
 pkgver=0.4.7.2
 _tarball="${_pkgname}-${pkgver}-x86_64_linux.tar.xz"
-pkgrel=1
+pkgrel=3
 pkgdesc="Private, fast, and honest web browser based on Chromium"
 arch=('x86_64')
 url="https://github.com/imputnet/helium-linux"
@@ -27,7 +27,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
             'upower: Battery Status API support')
 source_x86_64=(
     "${_tarball}::https://github.com/imputnet/helium-linux/releases/download/${pkgver}/${_tarball}"
-  "helium.desktop::https://raw.githubusercontent.com/imputnet/helium-linux/main/package/helium.desktop"
+    "https://raw.githubusercontent.com/imputnet/helium-linux/${pkgver}/package/helium.desktop"
 )
 
 sha256sums_x86_64=('b8e1f57dffa7cf014a36b202359294654f978c9e912c380ebd2054d9ea2e4fc8'


### PR DESCRIPTION
- Bump Helium to `0.4.7.2`
- Remove `StartupWMClass` var from `.desktop` file (now included upstream)
- Now pulling `helium.desktop` from `$pkgver` rather than `main`
- Bump `pkgrel` to `3` to fix `sha256` checks on `helium.desktop`

Notes:
- `pkgrel 1` broken due to git mishap
- `pkgrel 2` `.desktop` from upstream `main` resulted in failing `sha256` checks