### PR TITLE
update: helium `0.5.8.1`

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,5 +1,6 @@
 # Maintainer: Sam Sinclair <sam at playleft dot com>
 # Contributor: Pujan Modha <pujan.pm@hotmail.com>
+# Contributor: init_harsh
 # /*
 #  * SPDX-FileCopyrightText: 2025 Arch Linux Contributors
 #  *

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Sam Sinclair <sam at playleft dot com>
 # Contributor: Pujan Modha <pujan.pm@hotmail.com>
+# Contributor: init_harsh
 # /*
 #  * SPDX-FileCopyrightText: 2025 Arch Linux Contributors
 #  *


### PR DESCRIPTION
- bump to latest version
- include `init_harsh` in contributor credits