### PR TITLE
fix: do not rename the supplied .desktop entry

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -62,9 +62,9 @@ package() {
     "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
   # Install icon for desktop file
   install -Dm644 "${pkgdir}/opt/${pkgname}/product_logo_256.png" \
-    "${pkgdir}/usr/share/pixmaps/${_pkgname}.png"
+    "${pkgdir}/usr/share/pixmaps/${_binaryname}.png"
   install -Dm644 "${pkgdir}/opt/${pkgname}/product_logo_256.png" \
-    "${pkgdir}/usr/share/icons/hicolor/256x256/apps/${_pkgname}.png"
+    "${pkgdir}/usr/share/icons/hicolor/256x256/apps/${_binaryname}.png"
   # Install Ungoogled Chromium license
   install -Dm644 "${srcdir}/LICENSE.ungoogled_chromium" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.ungoogled_chromium"


### PR DESCRIPTION
We no longer rename the supplied `helium.desktop` entry on install. This allows Helium to resolve the hard coded path internally and set itself as the default browser as expected.

Closes #20
